### PR TITLE
Fixed several UI/UX bugs on activity tracking page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 node_modules
 .DS_Store
 *.local
+.env

--- a/i18n_en.js
+++ b/i18n_en.js
@@ -94,7 +94,7 @@ export default {
   "Are you sure to delete carrier": "Are you sure to delete carrier {name}",
   "Carrier deleted successfully": "Carrier deleted successfully",
   "Carrier created successfully": "Carrier created successfully",
-  "Are you sure to delete": "Are you sure to delete deposit {name}",
+  "Are you sure to delete deposit": "Are you sure to delete deposit {name}",
   "Deposit deleted successfully": "Deposit deleted successfully",
   "Deposit created successfully": "Deposit created successfully",
   "Deposit updated successfully": "Deposit updated successfully",
@@ -117,7 +117,7 @@ export default {
   "Activity Type": "Activity Type",
   "Enter activity type": "Enter activity type",
   "Are you sure to delete activity type":
-    "Are you sure to delete activity type {name}",
+    "Are you sure you would like to delete this activity? ({name})",
   Custom: "Create Custom",
   "Activity deleted successfully": "Activity deleted successfully",
   "Activity type is required": "Activity type is required",

--- a/src/views/ActivityTracking/ActivityTrackingView.vue
+++ b/src/views/ActivityTracking/ActivityTrackingView.vue
@@ -162,6 +162,7 @@ const getActivitiesTypeOptions = async () => {
     isLoadingActivitiesModal.value = false;
   }
 };
+
 const editRow = (data) => {
   visible.value = true;
   currentRowData.value = data;
@@ -170,7 +171,7 @@ const editRow = (data) => {
 const showDeleteAlert = (data) => {
   toast.add({
     severity: "custom",
-    summary: t("Are you sure to delete", { name: data.activity }),
+    summary: t("Are you sure to delete activity type", { name: data.activity }),
     group: "activityTracking",
   });
   visibleAlert.value = true;

--- a/src/views/ActivityTracking/CreateActivities.vue
+++ b/src/views/ActivityTracking/CreateActivities.vue
@@ -131,7 +131,7 @@ const addDefaultFormData = () => {
   <CustomDialog
     :visible="props.visible"
     customClass="create-activities"
-    :header="props.currentRow?.id ? t('Update activity') : t('Create activity')"
+    :header="props.currentRowData?.id ? t('Update activity ') : t('Create activity')"
     @onChangeVisibleState="emit('onChangeVisibleState', false)"
     @show="addDefaultFormData"
   >
@@ -177,6 +177,7 @@ const addDefaultFormData = () => {
             placeholder="0"
             class="w-8 md:w-full"
             type="number"
+            min="1"
           />
           <h5 class="text-red-50 m-0" v-if="v$.quantity.$error">
             {{ t("Quantity is required") }}


### PR DESCRIPTION
✅ 1. Activity numbers are now managed through a modal, however, 0 is still an allowed input. The input needs to be changed to allow integers >=1.

✅ 2. While the activity can be deleted, the delete confirmation modal that pops up has a header that states “Are you sure to delete deposit DoorKnocks”. The wording of this modal needs to be changed to properly indicate the action that is taking place (we are not deleting a deposit, but rather an activity). 
 
✅ 3. Edit activity button opens window titled "Create Activity". This needs to be changed to reflect the fact that we are editing, not creating, an activity.